### PR TITLE
Robustify version info; fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ name = "my-lovely-package"
 build = "build.rs"
 
 [build-dependencies]
-git-version = "*"
+git-build-version = "*"
 ```
 
 In `build.rs`:
 
 ```
-extern crate git_version;
+extern crate git_build_version;
 
 const PACKAGE_TOP_DIR : &'static str = ".";
 


### PR DESCRIPTION
- use discover rather than open so that the path can be anywhere within
  the repo
- make the path up to version.rs if it doesn't exist
- show tags or OID
- add simple unit test to exercise code
- update README
