### PR TITLE
updated git2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ readme = "README.md"
 repository = "https://github.com/cstorey/git-build-version/"
 
 [dependencies]
-git2 = { version = "0.3.3", default-features = false, features = [] }
+git2 = { version = "0.4", default-features = false, features = [] }
 quick-error = "0.1.4"


### PR DESCRIPTION
because linking to two different versions of libgit2 is not possible:

```
native library `git2` is being linked to by more than one version of the
same package, but it can only be linked once; try updating or pinning
your dependencies to ensure that this package only shows up once

  libgit2-sys v0.4.2
    libgit2-sys v0.3.12
```
