### PR TITLE
Implement print_version for printing cargo keys, bump git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ readme = "README.md"
 repository = "https://github.com/cstorey/git-build-version/"
 
 [dependencies]
-git2 = { version = "0.4", default-features = false, features = [] }
+git2 = { version = "0.7", default-features = false, features = [] }
 quick-error = "0.1.4"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ build = "build.rs"
 git-build-version = "*"
 ```
 
+## Using compile-time environment variable (since Rust 1.19)
+
+
 In `build.rs`:
 
 ```
@@ -22,7 +25,28 @@ extern crate git_build_version;
 const PACKAGE_TOP_DIR : &'static str = ".";
 
 fn main() {
-    git_version::write_version(PACKAGE_TOP_DIR).expect("Saving git version");
+    git_build_version::print_version(PACKAGE_TOP_DIR).expect("Cannot get git revision");
+}
+```
+In your source files, eg: in your `src/main.rs`:
+```
+fn main() {
+    println!("Version: {} Build: {}", env!("CARGO_PKG_VERSION"), env!("GIT_SHA_SHORT"));
+}
+```
+
+## Using generated version.rs
+
+
+In `build.rs`:
+
+```
+extern crate git_build_version;
+
+const PACKAGE_TOP_DIR : &'static str = ".";
+
+fn main() {
+    git_version::write_version(PACKAGE_TOP_DIR).expect("Saving git version failed");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,5 +140,5 @@ fn generate_rerun_if_changed(git_dir_or_file : PathBuf) -> Result<(), Error> {
 
 #[test]
 fn test() {
-    write_version(".").expect("write version");
+    print_version(".").expect("write version");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ use std::convert::AsRef;
 use std::fs::{File, create_dir_all};
 use std::io::{Write, Read, BufWriter};
 use std::path::Path;
+use std::path::PathBuf;
+use std::fs;
 
 quick_error! {
     #[derive(Debug)]
@@ -19,6 +21,8 @@ quick_error! {
             from()
         }
         MissingEnvVar {
+        }
+        InvalidGitFormat {
         }
     }
 }
@@ -58,6 +62,79 @@ pub fn write_version <P: AsRef<Path>>(topdir: P) -> Result<(), Error> {
 
       try!(write!(file, "{}", content));
     }
+    Ok(())
+}
+
+pub fn print_version<P: AsRef<Path>>(topdir: P) -> Result<(), Error> {
+    let repo = try!(Repository::discover(topdir));
+    let desc = try!(repo.describe(&DescribeOptions::new().describe_tags().show_commit_oid_as_fallback(true)));
+    println!("cargo:rustc-env=GIT_SHA_SHORT={}", try!(desc.format(None)));
+    let git_head_path = PathBuf::from(repo.path());
+    generate_rerun_if_changed(git_head_path)
+}
+
+// Copied and modified from https://github.com/rustyhorde/vergen/blob/master/src/output/envvar.rs#L45
+fn generate_rerun_if_changed(git_dir_or_file : PathBuf) -> Result<(), Error> {
+    eprintln!("Git repository: {}", git_dir_or_file.display());
+    if let Ok(metadata) = fs::metadata(&git_dir_or_file) {
+        if metadata.is_dir() {
+            // Echo the HEAD path
+            let git_head_path = git_dir_or_file.join("HEAD");
+            println!("cargo:rerun-if-changed={}", git_head_path.display());
+
+            // Determine where HEAD points and echo that path also.
+            let mut f = File::open(&git_head_path)?;
+            let mut git_head_contents = String::new();
+            let _ = f.read_to_string(&mut git_head_contents)?;
+            eprintln!("HEAD contents: {}", git_head_contents);
+            let ref_vec: Vec<&str> = git_head_contents.split(": ").collect();
+
+            if ref_vec.len() == 2 {
+                let current_head_file = ref_vec[1];
+                let git_refs_path = git_dir_or_file.join(current_head_file);
+                println!("cargo:rerun-if-changed={}", git_refs_path.display());
+            } else {
+                eprintln!("You are most likely in a detached HEAD state");
+            };
+        } else if metadata.is_file() {
+            // We are in a worktree, so find out where the actual worktrees/<name>/HEAD file is.
+            let mut git_file = File::open(&git_dir_or_file)?;
+            let mut git_contents = String::new();
+            let _ = git_file.read_to_string(&mut git_contents)?;
+            let dir_vec: Vec<&str> = git_contents.split(": ").collect();
+            eprintln!(".git contents: {}", git_contents);
+            let git_path = dir_vec[1].trim();
+
+            // Echo the HEAD psth
+            let git_head_path = PathBuf::from(git_path).join("HEAD");
+            println!("cargo:rerun-if-changed={}", git_head_path.display());
+
+            // Find out what the full path to the .git dir is.
+            let mut actual_git_dir = PathBuf::from(git_path);
+            actual_git_dir.pop();
+            actual_git_dir.pop();
+
+            // Determine where HEAD points and echo that path also.
+            let mut f = File::open(&git_head_path)?;
+            let mut git_head_contents = String::new();
+            let _ = f.read_to_string(&mut git_head_contents)?;
+            eprintln!("HEAD contents: {}", git_head_contents);
+            let ref_vec: Vec<&str> = git_head_contents.split(": ").collect();
+
+            if ref_vec.len() == 2 {
+                let current_head_file = ref_vec[1];
+                let git_refs_path = actual_git_dir.join(current_head_file);
+                println!("cargo:rerun-if-changed={}", git_refs_path.display());
+            } else {
+                eprintln!("You are most likely in a detached HEAD state");
+            };
+        } else {
+            return Err(Error::MissingEnvVar);
+        };
+    } else {
+        eprintln!("Unable to generate 'cargo:rerun-if-changed'");
+    };
+
     Ok(())
 }
 


### PR DESCRIPTION
Inspired by https://github.com/rustyhorde/vergen I needed to have a crate that does not call git command but uses git2 library. It also uses [compile-time environment variables](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script) for commit id propagation as well as rebuild trigger when a change is committed (`rerun-if-changed`).